### PR TITLE
FM_Demo_Context_Submenu doesn't have an init() method, and doesn't need to call one

### DIFF
--- a/lib/class-fm-demo-context-submenu.php
+++ b/lib/class-fm-demo-context-submenu.php
@@ -37,8 +37,6 @@ class FM_Demo_Context_Submenu {
 
 		fm_register_submenu_page( 'option_fields', 'options-general.php', 'Meta Boxes' );
 		add_action( 'fm_submenu_option_fields', array( $this, 'options_init' ) );
-
-		add_action( 'init', array( $this, 'init' ) );
 	}
 
 	public function tools_init() {


### PR DESCRIPTION
Was throwing a PHP warning