### PR TITLE
Add functionality required for gutenberg

### DIFF
--- a/lib/class-fm-demo-data-structures.php
+++ b/lib/class-fm-demo-data-structures.php
@@ -45,7 +45,8 @@ class FM_Demo_Data_Structures {
 
 			register_post_type( $type, array_merge( array(
 				'public' => true,
-				'supports' => array( 'title' ),
+				'supports' => array( 'title', 'editor' ),
+				'show_in_rest' => true,
 				'labels' => array(
 					'name'               => $plural,
 					'singular_name'      => $singular,


### PR DESCRIPTION
Add's the editor to all post types and makes them available in the REST API. Both these changes are required in order to load Gutenberg when Gutenberg is enabled.

Addresses #16 